### PR TITLE
Revert "Bump i386/golang from 1.15.8-buster to 1.16.0-buster"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM i386/golang:1.16.0-buster as gobuild
+FROM i386/golang:1.15.8-buster as gobuild
 ARG VERSION
 ENV GOPATH=/go/src/app
 WORKDIR /go/src/app


### PR DESCRIPTION
still broken